### PR TITLE
feat:  add pagination route

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,17 @@ halo:
 #### 路由信息
 
 - 模板路径：/templates/photos.html
-- 访问路径：/photos
+- 访问路径：/photos | /photos/page/{page}
+
+#### 路由可选参数
+
+group: 图片分组名称, 对应 [#PhotoGroupVo](#photogroupvo).metadata.name
+
+示例：/photos?group=photo-group-UEcvi | /photos/page/1?group=photo-group-UEcvi
 
 #### 变量
 
-photos
+groups
 
 ##### 变量类型
 
@@ -86,6 +92,33 @@ List<[#PhotoGroupVo](#photogroupvo)>
         </li>
     </ul>
 </th:block>
+```
+
+#### 变量
+
+photos
+
+##### 变量类型
+
+[#UrlContextListResult\<PhotoVo>](#urlcontextlistresult)
+
+##### 示例
+
+```html
+<ul>
+    <li th:each="photo : ${photos.items}">
+        <img th:src="${photo.spec.url}" th:alt="${photo.spec.displayName}" width="280">
+    </li>
+</ul>
+<div th:if="${photos.hasPrevious() || photos.hasNext()}">
+   <a th:href="@{${photos.prevUrl}}">
+      <span>上一页</span>
+   </a>
+   <span th:text="${photos.page}"></span>
+   <a th:href="@{${photos.nextUrl}}">
+      <span>下一页</span>
+   </a>
+</div>
 ```
 
 ### Finder API
@@ -293,3 +326,22 @@ List<[#PhotoVo](#photovo)>
   "totalPages": 0                              // 总页数
 }
 ```
+
+#### UrlContextListResult<PhotoVo>
+
+```json
+{
+  "page": 0,                                   // 当前页码
+  "size": 0,                                   // 每页条数
+  "total": 0,                                  // 总条数
+  "items": "List<#PhotoVo>",                   // 图片列表数据
+  "first": true,                               // 是否为第一页
+  "last": true,                                // 是否为最后一页
+  "hasNext": true,                             // 是否有下一页
+  "hasPrevious": true,                         // 是否有上一页
+  "totalPages": 0,                             // 总页数
+  "prevUrl": "string",                         // 上一页链接
+  "nextUrl": "string"                          // 下一页链接
+}
+```
+

--- a/src/main/java/run/halo/photos/PhotoRouter.java
+++ b/src/main/java/run/halo/photos/PhotoRouter.java
@@ -2,19 +2,31 @@ package run.halo.photos;
 
 import static org.springframework.web.reactive.function.server.RequestPredicates.GET;
 import static org.springframework.web.reactive.function.server.RouterFunctions.route;
+import static run.halo.app.theme.router.PageUrlUtils.totalPage;
 
+import java.net.URI;
+import java.net.URL;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.AllArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.server.HandlerFunction;
 import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
+import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Mono;
+import run.halo.app.infra.utils.PathUtils;
 import run.halo.app.plugin.ReactiveSettingFetcher;
+import run.halo.app.theme.router.PageUrlUtils;
+import run.halo.app.theme.router.UrlContextListResult;
 import run.halo.photos.finders.PhotoFinder;
 import run.halo.photos.vo.PhotoGroupVo;
+import run.halo.photos.vo.PhotoVo;
 
 /**
  * Provides a <code>/photos</code> route for the topic end to handle routing.
@@ -36,15 +48,57 @@ public class PhotoRouter {
      */
     @Bean
     RouterFunction<ServerResponse> photoRouter() {
-        return route(GET("/photos"), handlerFunction());
+        return route(GET("/photos").or(GET("/photos/page/{page:\\d+}")),
+            handlerFunction()
+        );
     }
     
     private HandlerFunction<ServerResponse> handlerFunction() {
         return request -> ServerResponse.ok().render("photos",
-            Map.of("groups", photoGroups(), ModelConst.TEMPLATE_ID, "photos",
+            Map.of("groups", photoGroups(),
+                "photos", photoList(request),
+                ModelConst.TEMPLATE_ID, "photos",
                 "title", getPhotosTitle()
             )
         );
+    }
+    
+    private Mono<UrlContextListResult<PhotoVo>> photoList(ServerRequest request) {
+        String path = request.path();
+        int pageNum = pageNumInPathVariable(request);
+        String group = groupPathQueryParam(request);
+        return this.settingFetcher.get("base")
+            .map(item -> item.get("pageSize").asInt(10))
+            .defaultIfEmpty(10)
+            .flatMap(pageSize -> photoFinder.list(pageNum, pageSize, group)
+                .map(list -> new UrlContextListResult.Builder<PhotoVo>()
+                    .listResult(list)
+                    .nextUrl(appendGroupParam(
+                        PageUrlUtils.nextPageUrl(path, totalPage(list)), group)
+                    )
+                    .prevUrl(appendGroupParam(PageUrlUtils.prevPageUrl(path), group))
+                    .build()
+                )
+            );
+        
+    }
+    
+    private static String appendGroupParam(String path, String group) {
+        return UriComponentsBuilder.fromPath(path)
+            .queryParamIfPresent("group", Optional.ofNullable(group))
+            .build()
+            .toString();
+    }
+    
+    private int pageNumInPathVariable(ServerRequest request) {
+        String page = request.pathVariables().get("page");
+        return NumberUtils.toInt(page, 1);
+    }
+    
+    private String groupPathQueryParam(ServerRequest request) {
+        return request.queryParam("group")
+            .filter(StringUtils::isNotBlank)
+            .orElse(null);
     }
     
     Mono<String> getPhotosTitle() {

--- a/src/main/java/run/halo/photos/PhotoRouter.java
+++ b/src/main/java/run/halo/photos/PhotoRouter.java
@@ -37,6 +37,8 @@ import run.halo.photos.vo.PhotoVo;
 @AllArgsConstructor
 public class PhotoRouter {
     
+    private static final String GROUP_PARAM = "group";
+    
     private PhotoFinder photoFinder;
     
     private final ReactiveSettingFetcher settingFetcher;
@@ -85,7 +87,7 @@ public class PhotoRouter {
     
     private static String appendGroupParam(String path, String group) {
         return UriComponentsBuilder.fromPath(path)
-            .queryParamIfPresent("group", Optional.ofNullable(group))
+            .queryParamIfPresent(GROUP_PARAM, Optional.ofNullable(group))
             .build()
             .toString();
     }
@@ -96,7 +98,7 @@ public class PhotoRouter {
     }
     
     private String groupPathQueryParam(ServerRequest request) {
-        return request.queryParam("group")
+        return request.queryParam(GROUP_PARAM)
             .filter(StringUtils::isNotBlank)
             .orElse(null);
     }

--- a/src/main/resources/extensions/settings.yaml
+++ b/src/main/resources/extensions/settings.yaml
@@ -12,3 +12,8 @@ spec:
           name: title
           validation: required
           value: "图库"
+        - $formkit: text
+          label: 相册列表显示条数
+          name: pageSize
+          validation: required|Number
+          value: 20


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

为 `photos` 增加分页路由，并且支持 `group` 参数。如下

1. /photos
2. /photos?group={group}
3. /photos/page/{page}
4. /photos/page/{page}?group={group}

`photos` 路由下将新增 `photos` 参数，为携带分页参数的 [UrlContextListResult](https://github.com/halo-dev/halo/blob/bf2b92e77c35d70c85db4141a14702c188f1d45b/api/src/main/java/run/halo/app/theme/router/UrlContextListResult.java#L17) 类型

#### Which issue(s) this PR fixes:

Fixes #9 

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

```release-note
增加分页路由并支持 group 参数
```
