### PR TITLE
fix: resolve the issue of group display conflicts caused by route query

### DIFF
--- a/console/src/components/GroupList.vue
+++ b/console/src/components/GroupList.vue
@@ -29,7 +29,7 @@ const groupEditingModal = ref(false);
 
 const updateGroup = ref<PhotoGroup>();
 
-const selectedGroup = useRouteQuery<string>("group");
+const selectedGroup = useRouteQuery<string>("photo-group");
 
 const { data: groups, refetch } = useQuery<PhotoGroup[]>({
   queryKey: [],


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

重命名图库分组 route query 为 `photo-group`。用以区别附件库中的 group，解决使用附件库导入图片后分组跳到首位的问题。

#### How to test it?

在非首个分组中，使用附件库导入图片，查看分组是否保持在当前选中的分组而不是跳转到首个分组。

#### Which issue(s) this PR fixes:

Fixes #23 

#### Does this PR introduce a user-facing change?
```release-note
解决使用附件库导入图片后会跳转到首个分组下的问题
```
