### PR TITLE
chore: remove deprecated plugin wrapper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,11 @@ plugins {
 }
 
 group 'run.halo.photos'
-sourceCompatibility = JavaVersion.VERSION_17
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
 
 repositories {
     mavenCentral()
@@ -14,7 +18,7 @@ repositories {
 }
 
 dependencies {
-    implementation platform('run.halo.tools.platform:plugin:2.9.0-SNAPSHOT')
+    implementation platform('run.halo.tools.platform:plugin:2.10.0-SNAPSHOT')
     compileOnly 'run.halo.app:api'
 
     testImplementation 'run.halo.app:api'

--- a/src/main/java/run/halo/photos/PhotoPlugin.java
+++ b/src/main/java/run/halo/photos/PhotoPlugin.java
@@ -1,9 +1,9 @@
 package run.halo.photos;
 
-import org.pf4j.PluginWrapper;
 import org.springframework.stereotype.Component;
 import run.halo.app.extension.SchemeManager;
 import run.halo.app.plugin.BasePlugin;
+import run.halo.app.plugin.PluginContext;
 
 /**
  * @author ryanwang
@@ -12,18 +12,18 @@ import run.halo.app.plugin.BasePlugin;
 @Component
 public class PhotoPlugin extends BasePlugin {
     private final SchemeManager schemeManager;
-    
-    public PhotoPlugin(PluginWrapper wrapper, SchemeManager schemeManager) {
-        super(wrapper);
+
+    public PhotoPlugin(PluginContext pluginContext, SchemeManager schemeManager) {
+        super(pluginContext);
         this.schemeManager = schemeManager;
     }
-    
+
     @Override
     public void start() {
         schemeManager.register(Photo.class);
         schemeManager.register(PhotoGroup.class);
     }
-    
+
     @Override
     public void stop() {
         schemeManager.unregister(schemeManager.get(Photo.class));

--- a/src/main/resources/plugin.yaml
+++ b/src/main/resources/plugin.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   enabled: true
   version: 1.0.0
-  requires: ">=2.8.0"
+  requires: ">=2.10.0"
   author:
     name: Halo
     website: https://github.com/halo-dev


### PR DESCRIPTION
### What this PR does?
移除对已过时的 PluginWrapper 的引用，Halo 2.18.0 版本后将不在支持从 BasePlugin 中获取 PluginWrapper ，也不再支持依赖注入 PluginWrapper，使用 PluginContext 代替

see also https://github.com/halo-dev/halo/pull/6243 for more details

```release-note
None
```